### PR TITLE
Improve debugging

### DIFF
--- a/lib/shift_planning/api_error.rb
+++ b/lib/shift_planning/api_error.rb
@@ -1,9 +1,13 @@
 module ShiftPlanning
   class ApiError < Exception
     attr_accessor :message
+    attr_accessor :request_body
+    attr_accessor :response_body
 
-    def initialize(response)
+    def initialize(response, request_body, response_body)
       @message = message_for_status(response["status"])
+      @request_body = request_body
+      @repsonse_body = response_body
     end
 
     def message_for_status(status)

--- a/lib/shift_planning/api_error.rb
+++ b/lib/shift_planning/api_error.rb
@@ -7,7 +7,7 @@ module ShiftPlanning
     def initialize(response, request_body, response_body)
       @message = message_for_status(response["status"])
       @request_body = request_body
-      @repsonse_body = response_body
+      @response_body = response_body
     end
 
     def message_for_status(status)

--- a/lib/shift_planning/client.rb
+++ b/lib/shift_planning/client.rb
@@ -52,7 +52,7 @@ module ShiftPlanning
       })
       response = HTTP.with(@headers).post(@url, body)
       result = JSON.parse(response)
-      raise ApiError.new(result) if @strict && is_error_response?(result)
+      raise ApiError.new(result, body, response) if @strict && is_error_response?(result)
       result
     end
 


### PR DESCRIPTION
Attach the raw request/response bodies to ApiError to make it easier to debug when things go wrong.
